### PR TITLE
feat: provide updated api endpoints when calling getPredefinedHosts()

### DIFF
--- a/src/PayoneCommercePlatform/Sdk/CommunicatorConfiguration.php
+++ b/src/PayoneCommercePlatform/Sdk/CommunicatorConfiguration.php
@@ -257,11 +257,11 @@ class CommunicatorConfiguration
     {
         return [
             "prod" => [
-                "url" => "https://commerce-api.payone.com",
+                "url" => "https://api.commerce.payone.com",
                 "description" => "Production URL",
             ],
             "preprod" => [
-                "url" => "https://preprod.commerce-api.payone.com",
+                "url" => "https://api.preprod.commerce.payone.com",
                 "description" => "Pre-Production URL",
             ]
         ];


### PR DESCRIPTION
BREAKING CHANGE: When the host for CommunicatorConfiguration is provided
`getPredefinedHosts()` it now points to a different url
